### PR TITLE
fix: resolve null reference issue

### DIFF
--- a/adsk.ts.job.shared/adsk.ts.job.common.cs
+++ b/adsk.ts.job.shared/adsk.ts.job.common.cs
@@ -329,7 +329,7 @@ namespace adsk.ts.job.shared
                         FileAssocArray[] fileAssocArray = _WebSrvMgr.DocumentService.GetFileAssociationsByIds(new long[] { mFile.Id }, FileAssociationTypeEnum.None, false, FileAssociationTypeEnum.Attachment, false, false, false);
                         foreach (FileAssocArray fileAssoc in fileAssocArray)
                         {
-                            if (fileAssoc.FileAssocs == null || fileAssoc.FileAssocs.Length == 0)
+                            if (fileAssoc.FileAssocs == null || fileAssoc.FileAssocs == null)
                                 continue;
                             foreach (FileAssoc assoc in fileAssoc.FileAssocs)
                             {


### PR DESCRIPTION
fileAssocArray.Fileassocs is null (not length 0) if no attachments are present