### PR TITLE
Add ExportPath setting for configurable export destinations.

### DIFF
--- a/adsk.ts.acad.dwg2d.create.inventor/JobExtension.cs
+++ b/adsk.ts.acad.dwg2d.create.inventor/JobExtension.cs
@@ -220,6 +220,7 @@ namespace adsk.ts.acad.dwg2d.create.inventor
             // use shared code to download the file
             adsktsshared.JobCommon tsJobCommon = new(connection, mWsMgr, mTrace);
             string mDocPath = tsJobCommon.mDownloadFile(mFile);
+            string exportDir = tsJobCommon.mResolveExportLocalDirectory(settings.ExportPath, mFile, mDocPath);
             string mExt = System.IO.Path.GetExtension(mDocPath);
 
             mTrace.WriteLine("Job successfully downloaded source file(s) for translation.");
@@ -255,7 +256,7 @@ namespace adsk.ts.acad.dwg2d.create.inventor
                         }
 
                         //delete existing export file; note the resulting file name is e.g. "Drawing.idw.dwg
-                        string mExpFileName = mDocPath + ".dwg";
+                        string mExpFileName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".dwg");
                         if (System.IO.File.Exists(mExpFileName))
                         {
                             System.IO.FileInfo fileInfo = new FileInfo(mExpFileName);

--- a/adsk.ts.acad.dwg2d.create.inventor/Settings.cs
+++ b/adsk.ts.acad.dwg2d.create.inventor/Settings.cs
@@ -34,6 +34,9 @@ namespace adsk.ts.acad.dwg2d.create.inventor
         [XmlElement("OutputPath")]
         public string OutPutPath;
 
+        [XmlElement("ExportPath")]
+        public string ExportPath;
+
         [XmlElement("DwgIniFile2D")]
         public string DwgIniFile2D;
 

--- a/adsk.ts.acad.dwg2d.create.inventor/adsk.ts.acad.dwg2d.create.inventor.settings.xml
+++ b/adsk.ts.acad.dwg2d.create.inventor/adsk.ts.acad.dwg2d.create.inventor.settings.xml
@@ -20,6 +20,12 @@
   <!-- Copy source file's system comment to the export file's system comment; accepted values are True/False -->
   <CopySystemComment>False</CopySystemComment>
 
+  <!-- Export destination. Leave empty to export next to the source file. -->
+  <!-- Absolute:   $/Designs/Exports -->
+  <!-- Relative up:    ..\Exports  or  ..\..\Exports  (.. = one level up per segment) -->
+  <!-- Relative down:  Exports  (subfolder under the source file's folder) -->
+  <ExportPath></ExportPath>
+
   <!-- Output Path -->
   <!--  The job can copy the resulting file(s) to the given output path after check-in-->
   <OutputPath>C:\Temp\</OutputPath>

--- a/adsk.ts.export3d.create.inventor/JobExtension.cs
+++ b/adsk.ts.export3d.create.inventor/JobExtension.cs
@@ -256,6 +256,7 @@ namespace adsk.ts.export3d.create.inventor
             // use shared code to download the file
             adsktsshared.JobCommon tsJobCommon = new(connection, mWsMgr, mTrace);
             string mDocPath = tsJobCommon.mDownloadFile(mFile);
+            string exportDir = tsJobCommon.mResolveExportLocalDirectory(settings.ExportPath, mFile, mDocPath);
             string mExt = System.IO.Path.GetExtension(mDocPath);
 
             mTrace.WriteLine("Job successfully downloaded source file(s) for translation.");
@@ -291,7 +292,7 @@ namespace adsk.ts.export3d.create.inventor
                         }
 
                         //delete existing export file; note the resulting file name is e.g. "Drawing.idw.dwg
-                        string mExpFileName = mDocPath + ".dwg";
+                        string mExpFileName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".dwg");
                         if (System.IO.File.Exists(mExpFileName))
                         {
                             System.IO.FileInfo fileInfo = new FileInfo(mExpFileName);
@@ -383,7 +384,7 @@ namespace adsk.ts.export3d.create.inventor
                             mTransOptions.Value["Description"] = "Sample-Job Step Translator using VaultInventorServer";
                             mTransContext.Type = IOMechanismEnum.kFileBrowseIOMechanism;
                             //delete local file if exists, as the export wouldn't overwrite
-                            string mExpFileName = mDocPath + ".stp";
+                            string mExpFileName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".stp");
                             if (System.IO.File.Exists(mExpFileName))
                             {
                                 System.IO.File.SetAttributes(mExpFileName, System.IO.FileAttributes.Normal);
@@ -442,7 +443,7 @@ namespace adsk.ts.export3d.create.inventor
                             mTransOptions.Value["Version"] = 102; //default
                             mTransContext.Type = IOMechanismEnum.kFileBrowseIOMechanism;
                             //delete local file if exists, as the export wouldn't overwrite
-                            string mExpFileName = mDocPath + ".jt";
+                            string mExpFileName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".jt");
                             if (System.IO.File.Exists(mExpFileName))
                             {
                                 System.IO.File.SetAttributes(mExpFileName, System.IO.FileAttributes.Normal);

--- a/adsk.ts.export3d.create.inventor/Settings.cs
+++ b/adsk.ts.export3d.create.inventor/Settings.cs
@@ -46,6 +46,9 @@ namespace adsk.ts.export3d.create.inventor
         [XmlElement("OutputPath")]
         public string OutPutPath;
 
+        [XmlElement("ExportPath")]
+        public string ExportPath;
+
         #region for future use
         //[XmlElement("OutputPath")]
         //public string mOutPutPath;

--- a/adsk.ts.export3d.create.inventor/adsk.ts.export3d.create.inventor.settings.xml
+++ b/adsk.ts.export3d.create.inventor/adsk.ts.export3d.create.inventor.settings.xml
@@ -22,6 +22,12 @@
   <!-- Copy source file's system comment to the export file's system comment; accepted values are True/False -->
   <CopySystemComment>False</CopySystemComment>
 
+  <!-- Export destination. Leave empty to export next to the source file. -->
+  <!-- Absolute:   $/Designs/Exports -->
+  <!-- Relative up:    ..\Exports  or  ..\..\Exports  (.. = one level up per segment) -->
+  <!-- Relative down:  Exports  (subfolder under the source file's folder) -->
+  <ExportPath></ExportPath>
+
   <!-- Output Path -->
   <!--  The job can copy the resulting file(s) to the given output path after check-in-->
   <OutputPath>C:\Temp\</OutputPath>

--- a/adsk.ts.image.create.inventor/JobExtension.cs
+++ b/adsk.ts.image.create.inventor/JobExtension.cs
@@ -222,6 +222,7 @@ namespace adsk.ts.image.create.inventor
             // use shared code to download the file
             adsktsshared.JobCommon tsJobCommon = new(connection, mWsMgr, mTrace);
             string mDocPath = tsJobCommon.mDownloadFile(mFile);
+            string exportDir = tsJobCommon.mResolveExportLocalDirectory(settings.ExportPath, mFile, mDocPath);
             string mExt = System.IO.Path.GetExtension(mDocPath);
 
             mTrace.WriteLine("Job successfully downloaded source file(s) for translation.");
@@ -249,7 +250,7 @@ namespace adsk.ts.image.create.inventor
                     mDoc = mInv.Documents.Open(mDocPath);
 
                     //delete existing export file; note the resulting file name is e.g. "Drawing.idw.dwg
-                    string mExpFileName = mDocPath + "." + mSettings.ImgFileType.ToLower();
+                    string mExpFileName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + "." + mSettings.ImgFileType.ToLower());
                     if (System.IO.File.Exists(mExpFileName))
                     {
                         System.IO.FileInfo fileInfo = new FileInfo(mExpFileName);

--- a/adsk.ts.image.create.inventor/Settings.cs
+++ b/adsk.ts.image.create.inventor/Settings.cs
@@ -43,6 +43,9 @@ namespace adsk.ts.image.create.inventor
         [XmlElement("OutputPath")]
         public string OutPutPath;
 
+        [XmlElement("ExportPath")]
+        public string ExportPath;
+
         #region for future use
         //[XmlElement("OutputPath")]
         //public string mOutPutPath;

--- a/adsk.ts.image.create.inventor/adsk.ts.image.create.inventor.settings.xml
+++ b/adsk.ts.image.create.inventor/adsk.ts.image.create.inventor.settings.xml
@@ -20,6 +20,12 @@
   <!-- Copy source file's system comment to the export file's system comment; accepted values are True/False -->
   <CopySystemComment>False</CopySystemComment>
 
+  <!-- Export destination. Leave empty to export next to the source file. -->
+  <!-- Absolute:   $/Designs/Exports -->
+  <!-- Relative up:    ..\Exports  or  ..\..\Exports  (.. = one level up per segment) -->
+  <!-- Relative down:  Exports  (subfolder under the source file's folder) -->
+  <ExportPath></ExportPath>
+
   <!-- Output Path -->
   <!--  The job can copy the resulting file(s) to the given output path after check-in-->
   <OutputPath>C:\Temp\</OutputPath>

--- a/adsk.ts.job.shared/adsk.ts.job.common.cs
+++ b/adsk.ts.job.shared/adsk.ts.job.common.cs
@@ -10,6 +10,8 @@ using Inventor;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Text;
 using static System.Net.Mime.MediaTypeNames;
 using ACET = Autodesk.Connectivity.Explorer.ExtensibilityTools;
@@ -113,6 +115,236 @@ namespace adsk.ts.job.shared
         }
 
         /// <summary>
+        /// Resolves the configured ExportPath to a local working-folder directory, creating the
+        /// corresponding Vault folder (and local directory) when it does not yet exist.
+        /// Relative paths starting with <c>..</c> navigate upward from the source file's Vault
+        /// folder by one or more levels (<c>..\Exports</c>, <c>..\..\Exports</c>, etc.).
+        /// Paths without a leading <c>..</c> are appended as subfolders under the source folder.
+        /// </summary>
+        public string mResolveExportLocalDirectory(string? exportPath, ACW.File sourceFile, string sourceLocalPath)
+        {
+            ACW.Folder sourceFolder = mGetSourceFolder(sourceFile);
+            string sourceFolderVaultPath = mNormalizeVaultFolderPath(sourceFolder.FullName);
+
+            if (string.IsNullOrWhiteSpace(exportPath))
+            {
+                return System.IO.Path.GetDirectoryName(sourceLocalPath)
+                    ?? throw new Exception("Job could not determine the local directory for source file " + sourceFile.Name + ".");
+            }
+
+            string targetVaultFolderPath = mResolveExportVaultFolderPath(exportPath.Trim(), sourceFolderVaultPath);
+            ACW.Folder targetFolder = mEnsureVaultFolderExists(targetVaultFolderPath);
+            string localDirectory = mMapVaultFolderToLocalPath(targetFolder.FullName);
+
+            if (!Directory.Exists(localDirectory))
+            {
+                Directory.CreateDirectory(localDirectory);
+            }
+
+            _trace.WriteLine("Job resolved export folder: Vault=" + targetFolder.FullName + ", local=" + localDirectory + ".");
+            return localDirectory;
+        }
+
+        private ACW.Folder mGetSourceFolder(ACW.File sourceFile)
+        {
+            ACW.Folder? sourceFolder = _WebSrvMgr.DocumentService.FindFoldersByIds([sourceFile.FolderId]).FirstOrDefault();
+            if (sourceFolder == null || sourceFolder.Id == -1)
+            {
+                throw new Exception("Vault folder with Id=" + sourceFile.FolderId + " not found for source file " + sourceFile.Name + ".");
+            }
+
+            return sourceFolder;
+        }
+
+        private static string mNormalizeVaultFolderPath(string vaultFolderPath)
+        {
+            string normalizedPath = vaultFolderPath.Replace('\\', '/').Trim();
+            while (normalizedPath.Contains("//", StringComparison.Ordinal))
+            {
+                normalizedPath = normalizedPath.Replace("//", "/", StringComparison.Ordinal);
+            }
+
+            if (normalizedPath.Length > 1)
+            {
+                normalizedPath = normalizedPath.TrimEnd('/');
+            }
+
+            return normalizedPath;
+        }
+
+        private static string mResolveExportVaultFolderPath(string exportPath, string sourceFolderVaultPath)
+        {
+            exportPath = exportPath.Replace('\\', '/').Trim();
+            while (exportPath.StartsWith('/'))
+            {
+                exportPath = exportPath.Substring(1);
+            }
+
+            if (exportPath.StartsWith("$/", StringComparison.Ordinal))
+            {
+                return mNormalizeVaultFolderPath(exportPath);
+            }
+
+            // Relative upward paths: each ".." segment moves one level up from the source folder.
+            if (exportPath.StartsWith("..", StringComparison.Ordinal))
+            {
+                return mNormalizeVaultFolderPath(mApplyRelativeVaultPath(sourceFolderVaultPath, exportPath));
+            }
+
+            return mNormalizeVaultFolderPath(sourceFolderVaultPath + "/" + exportPath);
+        }
+
+        /// <summary>
+        /// Applies relative Vault path segments from a base folder. Supports multiple parent
+        /// traversals via repeated <c>..</c> segments before descending into child folders.
+        /// </summary>
+        private static string mApplyRelativeVaultPath(string baseVaultFolderPath, string relativePath)
+        {
+            List<string> segments = baseVaultFolderPath
+                .Split('/', StringSplitOptions.RemoveEmptyEntries)
+                .ToList();
+
+            if (segments.Count == 0 || segments[0] != "$")
+            {
+                throw new Exception("Invalid Vault folder path: " + baseVaultFolderPath + ".");
+            }
+
+            foreach (string part in relativePath.Split('/', '\\', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (part == ".")
+                {
+                    continue;
+                }
+
+                if (part == "..")
+                {
+                    if (segments.Count <= 1)
+                    {
+                        throw new Exception("Export path resolves above the Vault root: " + relativePath + ".");
+                    }
+
+                    segments.RemoveAt(segments.Count - 1);
+                    continue;
+                }
+
+                segments.Add(part);
+            }
+
+            if (segments.Count <= 1)
+            {
+                return "$/";
+            }
+
+            return "$/" + string.Join("/", segments.Skip(1));
+        }
+
+        private ACW.Folder mEnsureVaultFolderExists(string vaultFolderPath)
+        {
+            vaultFolderPath = mNormalizeVaultFolderPath(vaultFolderPath);
+            ACW.Folder? existingFolder = mGetFolderByPathOrNull(vaultFolderPath);
+            if (existingFolder != null)
+            {
+                return existingFolder;
+            }
+
+            if (vaultFolderPath == "$/" || vaultFolderPath == "$")
+            {
+                return _WebSrvMgr.DocumentService.GetFolderRoot();
+            }
+
+            if (!vaultFolderPath.StartsWith("$/", StringComparison.Ordinal))
+            {
+                throw new Exception("Invalid export Vault folder path: " + vaultFolderPath + ".");
+            }
+
+            string[] folderNames = vaultFolderPath.Substring(2).Split('/', StringSplitOptions.RemoveEmptyEntries);
+            ACW.Folder currentFolder = _WebSrvMgr.DocumentService.GetFolderRoot();
+            string currentVaultPath = "$/";
+
+            foreach (string folderName in folderNames)
+            {
+                currentVaultPath = currentVaultPath == "$/"
+                    ? "$/" + folderName
+                    : currentVaultPath + "/" + folderName;
+
+                ACW.Folder? nextFolder = mGetFolderByPathOrNull(currentVaultPath);
+                if (nextFolder == null)
+                {
+                    currentFolder = _WebSrvMgr.DocumentService.AddFolder(folderName, currentFolder.Id, false);
+                    _trace.WriteLine("Job created Vault folder: " + currentVaultPath + ".");
+                }
+                else
+                {
+                    currentFolder = nextFolder;
+                }
+            }
+
+            return currentFolder;
+        }
+
+        private ACW.Folder? mGetFolderByPathOrNull(string vaultFolderPath)
+        {
+            try
+            {
+                ACW.Folder folder = _WebSrvMgr.DocumentService.GetFolderByPath(vaultFolderPath);
+                if (folder != null && folder.Id > 0)
+                {
+                    return folder;
+                }
+            }
+            catch (Exception ex)
+            {
+                _trace.WriteLine("Vault folder lookup failed for " + vaultFolderPath + ": " + ex.Message);
+            }
+
+            return null;
+        }
+
+        private string mMapVaultFolderToLocalPath(string vaultFolderPath)
+        {
+            return _connection.WorkingFoldersManager.GetWorkingFolder(mNormalizeVaultFolderPath(vaultFolderPath)).FullPath;
+        }
+
+        private ACW.Folder mGetUploadFolderFromLocalPath(string localFilePath, ACW.File sourceFile)
+        {
+            string? localDirectory = System.IO.Path.GetDirectoryName(localFilePath);
+            if (localDirectory == null)
+            {
+                throw new Exception("Job could not determine the local directory for export file " + localFilePath + ".");
+            }
+
+            string vaultFolderPath = mMapLocalPathToVaultFolder(localDirectory);
+            ACW.Folder? uploadFolder = mGetFolderByPathOrNull(vaultFolderPath);
+            if (uploadFolder != null)
+            {
+                return uploadFolder;
+            }
+
+            // Fall back to the source folder when the export sits next to the downloaded source file.
+            return mGetSourceFolder(sourceFile);
+        }
+
+        private string mMapLocalPathToVaultFolder(string localDirectoryPath)
+        {
+            string workingFolderRoot = _connection.WorkingFoldersManager.GetWorkingFolder("$/").FullPath;
+            string normalizedLocalDirectory = System.IO.Path.GetFullPath(localDirectoryPath).TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
+            string normalizedWorkingFolderRoot = System.IO.Path.GetFullPath(workingFolderRoot).TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
+
+            if (!normalizedLocalDirectory.StartsWith(normalizedWorkingFolderRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new Exception("Export file directory " + localDirectoryPath + " is outside the Vault working folder " + workingFolderRoot + ".");
+            }
+
+            string relativePath = normalizedLocalDirectory.Substring(normalizedWorkingFolderRoot.Length).TrimStart(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
+            if (string.IsNullOrEmpty(relativePath))
+            {
+                return "$/";
+            }
+
+            return "$/" + relativePath.Replace('\\', '/');
+        }
+
+        /// <summary>
         /// Resolves the system comment to use when updating the export file's properties.
         /// If the source file is in a consumable lifecycle state the comment of the first iteration
         /// that entered the current revision+state combination is returned, so that downstream
@@ -185,9 +417,7 @@ namespace adsk.ts.job.shared
 
                     //add resulting export file to Vault if it doesn't exist, otherwise update the existing one
 
-                    ACW.Folder? mFolder = _WebSrvMgr.DocumentService.FindFoldersByIds([mFile.FolderId]).FirstOrDefault();
-                    if (mFolder == null || mFolder.Id == -1)
-                        throw new Exception("Vault folder with Id=" + mFile.FolderId + " not found");
+                    ACW.Folder mFolder = mGetUploadFolderFromLocalPath(mExportFileInfo.FullName, mFile);
                     string vaultFilePath = System.IO.Path.Combine(mFolder.FullName, mExportFileInfo.Name).Replace("\\", "/");
 
                     ACW.File wsFile = _WebSrvMgr.DocumentService.FindLatestFilesByPaths(new string[] { vaultFilePath }).First();

--- a/adsk.ts.nwd.create.navisworks/JobExtension.cs
+++ b/adsk.ts.nwd.create.navisworks/JobExtension.cs
@@ -189,6 +189,7 @@ namespace adsk.ts.nwd.create.navisworks
             // use shared code to download the file
             adsktsshared.JobCommon tsJobCommon = new(connection, mWsMgr, mTrace);
             string mDocPath = tsJobCommon.mDownloadFile(mFile);
+            string exportDir = tsJobCommon.mResolveExportLocalDirectory(settings.ExportPath, mFile, mDocPath);
             string mExt = System.IO.Path.GetExtension(mDocPath);
 
             mTrace.WriteLine("Job successfully downloaded source file(s) for translation.");
@@ -200,14 +201,14 @@ namespace adsk.ts.nwd.create.navisworks
                 if ((item == "NWD" || item == "NWD+DWF") && mNavisworksAutomation != null)
                 {
                     //delete existing export files; note the resulting file name is e.g. "Assembly.iam.nwd
-                    string mNwdName = mDocPath + ".nwd";
+                    string mNwdName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".nwd");
                     if (System.IO.File.Exists(mNwdName))
                     {
                         System.IO.FileInfo fileInfo = new FileInfo(mNwdName);
                         fileInfo.IsReadOnly = false;
                         fileInfo.Delete();
                     }
-                    string mNWDWFName = mDocPath + ".dwf";
+                    string mNWDWFName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".dwf");
                     if (item == "NWD+DWF")
                     {
                         if (System.IO.File.Exists(mNWDWFName))
@@ -298,7 +299,7 @@ namespace adsk.ts.nwd.create.navisworks
                         if (mDocInfo.Exists)
                         {
                             //align the file name according our convention
-                            string mNwcUpload = mDocPath + ".nwc";
+                            string mNwcUpload = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".nwc");
                             if (System.IO.File.Exists(mNwcUpload))
                             {
                                 System.IO.FileInfo fileInfo = new FileInfo(mNwcUpload);

--- a/adsk.ts.nwd.create.navisworks/Settings.cs
+++ b/adsk.ts.nwd.create.navisworks/Settings.cs
@@ -40,6 +40,9 @@ namespace adsk.ts.nwd.create.navisworks
         [XmlElement("OutputPath")]
         public string OutPutPath;
 
+        [XmlElement("ExportPath")]
+        public string ExportPath;
+
         // added for future enhancement using Navisworks Plugins to export, instead of Automation
         //[XmlElement("NWDExcludeHiddenItems")]
         //public string NWDExcludeHiddenItems;

--- a/adsk.ts.nwd.create.navisworks/adsk.ts.nwd.create.navisworks.settings.xml
+++ b/adsk.ts.nwd.create.navisworks/adsk.ts.nwd.create.navisworks.settings.xml
@@ -18,6 +18,12 @@
   <!-- Copy source file's system comment to the export file's system comment; accepted values are True/False -->
   <CopySystemComment>False</CopySystemComment>
 
+  <!-- Export destination. Leave empty to export next to the source file. -->
+  <!-- Absolute:   $/Designs/Exports -->
+  <!-- Relative up:    ..\Exports  or  ..\..\Exports  (.. = one level up per segment) -->
+  <!-- Relative down:  Exports  (subfolder under the source file's folder) -->
+  <ExportPath></ExportPath>
+
   <!-- Output Path -->
   <!--  The job can copy the resulting file(s) to the given output path after check-in-->
   <OutputPath>C:\Temp\</OutputPath>

--- a/adsk.ts.pdf.create.slddrw/JobExtension.cs
+++ b/adsk.ts.pdf.create.slddrw/JobExtension.cs
@@ -203,6 +203,7 @@ namespace adsk.ts.pdf.create.slddrw
             // use shared code to download the file
             adsktsshared.JobCommon tsJobCommon = new adsktsshared.JobCommon(connection, mWsMgr, mTrace);
             string mDocPath = tsJobCommon.mDownloadFile(mFile);
+            string exportDir = tsJobCommon.mResolveExportLocalDirectory(settings.ExportPath, mFile, mDocPath);
             string mExt = System.IO.Path.GetExtension(mDocPath);
 
             mTrace.WriteLine("Job successfully downloaded source file(s) for translation.");
@@ -219,13 +220,13 @@ namespace adsk.ts.pdf.create.slddrw
                     // build the target PDF file name according the settings to include or exclude the source file extension
                     if (settings.IncludeSourceFileExtension.ToLower() == "true")
                     {
-                        mPDFName = mDocPath + ".pdf";
-                        mDXFName = mDocPath + ".dxf";
+                        mPDFName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".pdf");
+                        mDXFName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".dxf");
                     }
                     else
                     {
-                        mPDFName = mDocPath.ToLower().Replace(".slddrw", ".pdf");
-                        mDXFName = mDocPath.ToLower().Replace(".slddrw", ".dxf");
+                        mPDFName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileNameWithoutExtension(mDocPath) + ".pdf");
+                        mDXFName = System.IO.Path.Combine(exportDir, System.IO.Path.GetFileNameWithoutExtension(mDocPath) + ".dxf");
                     }
                     if (System.IO.File.Exists(mPDFName))
                     {

--- a/adsk.ts.pdf.create.slddrw/Settings.cs
+++ b/adsk.ts.pdf.create.slddrw/Settings.cs
@@ -46,6 +46,9 @@ namespace adsk.ts.pdf.create.slddrw
         [XmlElement("OutputPath")]
         public string OutPutPath;
 
+        [XmlElement("ExportPath")]
+        public string ExportPath;
+
         #region for future use
         //[XmlElement("OutputPath")]
         //public string mOutPutPath;

--- a/adsk.ts.pdf.create.slddrw/adsk.ts.pdf.create.slddrw.settings.xml
+++ b/adsk.ts.pdf.create.slddrw/adsk.ts.pdf.create.slddrw.settings.xml
@@ -23,6 +23,12 @@
   <!-- Copy source file's system comment to the export file's system comment; accepted values are True/False -->
   <CopySystemComment>False</CopySystemComment>
 
+  <!-- Export destination. Leave empty to export next to the source file. -->
+  <!-- Absolute:   $/Designs/Exports -->
+  <!-- Relative up:    ..\Exports  or  ..\..\Exports  (.. = one level up per segment) -->
+  <!-- Relative down:  Exports  (subfolder under the source file's folder) -->
+  <ExportPath></ExportPath>
+
   <!-- Output Path -->
   <!--  The job can copy the resulting file(s) to the given output path after check-in-->
   <OutputPath>C:\Temp\</OutputPath>

--- a/adsk.ts.rvt.create.inventor/JobExtension.cs
+++ b/adsk.ts.rvt.create.inventor/JobExtension.cs
@@ -130,7 +130,7 @@ namespace adsk.ts.rvt.create.inventor
             }
             finally
             {
-                // InventorServer is managed by the hosting context ó never call Quit() on it.
+                // InventorServer is managed by the hosting context ù never call Quit() on it.
                 // If we created an Inventor Application instance on our own, close it; otherwise only re-enable any addins we deactivated.
                 if (mInvApp != null)
                 {
@@ -404,6 +404,8 @@ namespace adsk.ts.rvt.create.inventor
                 mTrace.WriteLine("Job successfully downloaded source file(s) for translation.");
                 #endregion download source file(s)
 
+                string exportDir = tsJobCommon.mResolveExportLocalDirectory(settings.ExportPath, mFile, mDocPath);
+
                 // capture dependencies for upload later
                 #region capture dependencies
                 //we need to return all relationships during later check-in
@@ -441,7 +443,7 @@ namespace adsk.ts.rvt.create.inventor
 
                 Dictionary<string, object> mPresetObjects = mReadPresetMap();
 
-                // download the Revit template from Vault once; reused for all version ◊ preset iterations
+                // download the Revit template from Vault once; reused for all version ù preset iterations
                 string templateLocalPath = null;
                 if (mSettings.RevitTemplate != null && mSettings.RevitTemplate != "")
                 {
@@ -497,15 +499,15 @@ namespace adsk.ts.rvt.create.inventor
                     mAsmDoc.ComponentDefinition.ModelStates[1].Activate();
                 }
 
-                // run the version ◊ preset export loop; document stays open for all iterations
+                // run the version ù preset export loop; document stays open for all iterations
                 foreach (string rvtVersion in settings.TargetRevitVersions)
                 {
                     foreach (string presetName in settings.InventorPresetNames)
                     {
                         // compute unique output filename per iteration
                         string mExpFileName = isMultiExport
-                            ? mDocPath + "_" + rvtVersion + "_" + presetName + ".rvt"
-                            : mDocPath + ".rvt";
+                            ? System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + "_" + rvtVersion + "_" + presetName + ".rvt")
+                            : System.IO.Path.Combine(exportDir, System.IO.Path.GetFileName(mDocPath) + ".rvt");
 
                         mTrace.WriteLine("Job processes export: Revit version=" + rvtVersion + ", preset=" + presetName + ", output=" + System.IO.Path.GetFileName(mExpFileName));
 
@@ -531,8 +533,8 @@ namespace adsk.ts.rvt.create.inventor
                             mNewExportDef = true;
                             revitExportDef = mAsmDoc.ComponentDefinition.RevitExports.CreateDefinition();
 
-                            // derive path and file name from source file mDoc
-                            revitExportDef.Location = System.IO.Path.GetDirectoryName(mDocPath);
+                            // derive path and file name from resolved export directory
+                            revitExportDef.Location = exportDir;
                             revitExportDef.FileName = mExpFileName;
 
                             // set the target Revit version for this iteration
@@ -680,7 +682,7 @@ namespace adsk.ts.rvt.create.inventor
                     mDoc.Save2(false);
                 }
 
-                // close the document once after all version ◊ preset exports complete
+                // close the document once after all version ù preset exports complete
                 mDoc.Close(true);
 
                 // Deactivate the RVT Translator addin so ATF releases the out-of-process
@@ -791,7 +793,7 @@ namespace adsk.ts.rvt.create.inventor
         }
 
 
-        // Unified accessors ó null-coalescing between the two Inventor application types; no per-call conditionals needed.
+        // Unified accessors ù null-coalescing between the two Inventor application types; no per-call conditionals needed.
         private Inventor.Documents             InvDocuments             => mInvApp?.Documents             ?? mInvSrv.Documents;
         private Inventor.FileManager           InvFileManager           => mInvApp?.FileManager           ?? mInvSrv.FileManager;
         private Inventor.TransientObjects      InvTransientObjects      => mInvApp?.TransientObjects      ?? mInvSrv.TransientObjects;
@@ -961,7 +963,7 @@ namespace adsk.ts.rvt.create.inventor
 
             // ATF process hierarchy: ATFRevitRCEHost is the actual Revit engine host spawned by
             // ATFRevitBroker. The broker only exits after the host releases it, so we must wait
-            // for them in dependency order. WaitForExit observes the natural exit ó it does not
+            // for them in dependency order. WaitForExit observes the natural exit ù it does not
             // kill anything.
             const int timeoutMs = 15_000;
             foreach (string procName in (string[])["ATFRevitRCEHost", "ATFRevitBroker"])

--- a/adsk.ts.rvt.create.inventor/Settings.cs
+++ b/adsk.ts.rvt.create.inventor/Settings.cs
@@ -37,6 +37,9 @@ namespace adsk.ts.rvt.create.inventor
         [XmlElement("OutputPath")]
         public string OutPutPath;
 
+        [XmlElement("ExportPath")]
+        public string ExportPath;
+
         [XmlElement("InventorPreset")]
         public string InventorPreset;
 

--- a/adsk.ts.rvt.create.inventor/adsk.ts.rvt.create.inventor.settings.xml
+++ b/adsk.ts.rvt.create.inventor/adsk.ts.rvt.create.inventor.settings.xml
@@ -36,6 +36,12 @@
   <!-- Copy source file's system comment; accepted values are True/False -->
   <CopySystemComment>True</CopySystemComment>
 
+  <!-- Export destination. Leave empty to export next to the source file. -->
+  <!-- Absolute:   $/Designs/Revit Exports -->
+  <!-- Relative up:    ..\Revit Export  or  ..\..\Revit Export  (.. = one level up per segment) -->
+  <!-- Relative down:  Revit Export  (subfolder under the source file's folder) -->
+  <ExportPath></ExportPath>
+
   <!-- Output Path -->
   <!--  The job can copy the resulting file(s) to the given output path after check-in-->
   <OutputPath>C:\Temp\</OutputPath>

--- a/docs/job-collection.md
+++ b/docs/job-collection.md
@@ -35,13 +35,25 @@ Downloads a file from Vault to the local working folder, including all children 
 #### `mUploadFiles(mFile, filesToUpload, outPutPath?, copySourceComment?)`
 Uploads a list of local files back into Vault. For each file it:
 1. Optionally copies the file to a local output folder (if `OutputPath` is configured).
-2. Adds the file as a new Vault file if it does not yet exist, or checks it out and checks it back in as a new version if it does.
+2. Determines the target Vault folder from the export file's local path (via the working-folder mapping established during download). When `ExportPath` is empty, export files sit next to the source file locally and are uploaded to the source file's Vault folder — the existing default behaviour.
+3. Adds the file as a new Vault file if it does not yet exist, or checks it out and checks it back in as a new version if it does.
    - `.dwf` files are uploaded as `DesignVisualization` (hidden); all other files are uploaded as `DesignRepresentation`.
-3. Synchronises the revision label of the export file to match the source file's revision label.
-4. Synchronises all user-defined properties (UDPs) that are assigned to both the source file's category and the export file's category.
-5. Sets the system comment on the export file — see **CopySystemComment logic** below.
-6. For `DesignVisualization` files: synchronises the lifecycle state name from the source file.
-7. Attaches the export file to its source file using the appropriate attachment type (`DesignRepresentation` or `DesignVisualization`). Any pre-existing attachment with the same master ID is replaced.
+4. Synchronises the revision label of the export file to match the source file's revision label.
+5. Synchronises all user-defined properties (UDPs) that are assigned to both the source file's category and the export file's category.
+6. Sets the system comment on the export file — see **CopySystemComment logic** below.
+7. For `DesignVisualization` files: synchronises the lifecycle state name from the source file.
+8. Attaches the export file to its source file using the appropriate attachment type (`DesignRepresentation` or `DesignVisualization`). Any pre-existing attachment with the same master ID is replaced.
+
+#### Export path helpers
+
+Shared helpers on `JobCommon` resolve the `ExportPath` setting and prepare the local export directory before any host application (Inventor, Navisworks, SolidWorks) runs:
+
+| Helper | Purpose |
+|---|---|
+| `mResolveExportVaultFolder(exportPath, sourceFile)` | Resolves the configured path to a Vault folder path. Creates the folder (and any missing parent folders) in Vault when it does not yet exist. |
+| `mResolveExportLocalDirectory(exportPath, sourceFile)` | Maps the resolved Vault folder to a local working-folder path. Creates the local directory on the Job Processor machine if needed. Returns the directory where export files must be written. |
+
+See [Export Path Configuration (`ExportPath`)](#export-path-configuration-exportpath) for resolution rules and examples.
 
 #### `mGetSourceComment(mFile)` *(private)*
 Resolves the source file's system comment that will be written to the export file when `CopySystemComment = True`.
@@ -111,6 +123,7 @@ Opens an Inventor 2D drawing (`.idw` or `.dwg`) in VaultInventorServer and expor
 | `ExportFormats` | `2DDWG` | Currently only `2DDWG` is supported. Reserved for future additional formats. |
 | `DwgIniFile2D` | Path | Full local path to the Inventor DWG export configuration `.ini` file. This file controls layer mappings, DWG version, and all other translator-specific options. The file must be present on the Job Processor machine. |
 | `CopySystemComment` | `True` / `False` | See [CopySystemComment logic](#copysystemcomment-logic) below. |
+| `ExportPath` | Vault path | Optional export destination. Leave empty to export next to the source file (current default). See [Export Path Configuration](#export-path-configuration-exportpath). |
 | `OutputPath` | Path | Optional local folder to which the exported file is also copied after Vault check-in. Leave empty to disable the copy. |
 
 ---
@@ -150,6 +163,7 @@ Additional formats that Inventor supports (but are not yet wired up): `CATPart`,
 | `ExportFormats` | Comma-separated list | One or more format tokens from `3DDWG`, `STP`, `JT`. Example: `STP, JT`. Each token generates a separate output file. |
 | `ExcludeDesignSubstitute` | `True` / `False` | When `False` (default), files classified as `DesignSubstitute` are also exported. Set to `True` to skip them. |
 | `CopySystemComment` | `True` / `False` | See [CopySystemComment logic](#copysystemcomment-logic) below. |
+| `ExportPath` | Vault path | Optional export destination. See [Export Path Configuration](#export-path-configuration-exportpath). |
 | `OutputPath` | Path | Optional local folder for post-upload file copy. |
 
 ---
@@ -186,6 +200,7 @@ NWC files, when present, are uploaded as additional `DesignRepresentation` attac
 | `ExportFormats` | `NWD` or `NWD+DWF` | `NWD` creates only the NWD file. `NWD+DWF` additionally exports a DWF via the Navisworks `LcDwfExporterPlugin`. |
 | `NwdTemplate` | Vault path | Vault path to an NWD file to use as a base template (e.g. `$/Templates/Navisworks/Standard-Vertical-Z.nwd`). When set, Navisworks opens the template first and then appends the source file. Leave empty to open the source file directly. **Note:** using a template adds an additional Vault reference to the resulting NWD file. |
 | `CopySystemComment` | `True` / `False` | See [CopySystemComment logic](#copysystemcomment-logic) below. |
+| `ExportPath` | Vault path | Optional export destination. See [Export Path Configuration](#export-path-configuration-exportpath). |
 | `OutputPath` | Path | Optional local folder for post-upload file copy. |
 
 ---
@@ -238,6 +253,7 @@ Creates a simplified Revit (`.rvt`) file from an Inventor assembly using the Inv
 | `InventorPreset` | Vault path | Vault path to the Inventor simplification preset file (`.preset`), e.g. `$/Templates/Inventor/Presets/SimplifyCmd.preset`. This file contains the named simplification configurations. |
 | `InventorPresetName` | Comma-separated name(s) | One or more preset names defined inside the preset file, e.g. `RVT_Level_2` or `RVT_Level_1, RVT_Level_2`. All named `Preset` nodes in the preset file are loaded, so any custom preset name is supported alongside the built-in ones. Multiple values produce one output file per preset per Revit version. |
 | `CopySystemComment` | `True` / `False` | See [CopySystemComment logic](#copysystemcomment-logic) below. |
+| `ExportPath` | Vault path | Optional export destination. See [Export Path Configuration](#export-path-configuration-exportpath). |
 | `OutputPath` | Path | Optional local folder for post-upload file copy. |
 
 ---
@@ -274,6 +290,7 @@ Launches SolidWorks via COM automation, opens a SolidWorks drawing (`.slddrw`) a
 | `DxfSheetName` | String | Name of the drawing sheet that represents DXF content (e.g. `DXF`). Used in conjunction with `PdfIncludeDxfSheet`. |
 | `PdfIncludeDxfSheet` | `True` / `False` | When `False`, the sheet named by `DxfSheetName` is excluded from the PDF export and is instead saved as a separate `.dxf` file. When `True`, all sheets including the DXF sheet are included in the PDF and no separate DXF is created. |
 | `CopySystemComment` | `True` / `False` | See [CopySystemComment logic](#copysystemcomment-logic) below. |
+| `ExportPath` | Vault path | Optional export destination. See [Export Path Configuration](#export-path-configuration-exportpath). |
 | `OutputPath` | Path | Optional local folder for post-upload file copy. |
 
 ---
@@ -307,7 +324,113 @@ Opens an Inventor file in VaultInventorServer and renders a static image using a
 | `ExportFormats` | `IMAGE` | Currently only `IMAGE` is supported. The image file type is controlled separately by `ImgFileType`. |
 | `ImgFileType` | `BMP` / `PNG` / `GIF` / `JPG` / `TIFF` | File format for the rendered image. Passed directly to `Camera.SaveAsBitmap`. Default: `PNG`. |
 | `CopySystemComment` | `True` / `False` | See [CopySystemComment logic](#copysystemcomment-logic) below. |
+| `ExportPath` | Vault path | Optional export destination. See [Export Path Configuration](#export-path-configuration-exportpath). |
 | `OutputPath` | Path | Optional local folder for post-upload file copy. |
+
+---
+
+## Export Path Configuration (`ExportPath`)
+
+All export jobs share an optional `ExportPath` setting that controls **where export files are created locally** on the Job Processor machine. Because Vault downloads use `OrganizeFilesRelativeToCommonVaultRoot = true`, the local working-folder layout mirrors the Vault folder structure. Setting the correct local export directory therefore produces the expected Vault destination on upload — no separate Vault upload override is required.
+
+### Design principles
+
+| Principle | Detail |
+|---|---|
+| **Local path drives Vault path** | Jobs write export files to a resolved local directory. `mUploadFiles` derives the Vault upload folder from each file's local path via the working-folder mapping. |
+| **Admin-configured, auto-create** | The Job Processor admin sets `ExportPath` in the job settings XML. If the target Vault folder does not exist, the job creates it (and any missing intermediate folders) before export begins. |
+| **Backward compatible** | When `ExportPath` is empty, export files are written next to the downloaded source file and uploaded to the source file's Vault folder — identical to current behaviour. |
+| **Distinct from `OutputPath`** | `ExportPath` controls the primary export location. `OutputPath` remains an optional *additional* local copy made after Vault check-in. |
+
+### Setting values
+
+| Value | Type | Example | Result for source `$/Designs/P-00020/CAD/Assy.iam` |
+|---|---|---|---|
+| *(empty)* | Default | — | Local: next to source download. Vault: `$/Designs/P-00020/CAD/` |
+| Absolute Vault path | Starts with `$/` | `$/Designs/Revit Exports` | Vault: `$/Designs/Revit Exports/`. Local: mapped working-folder path. |
+| Relative — upward | Starts with `..` | `..\Revit Export` or `..\..\Common Exports` | Resolved from source folder; each `..` moves up one Vault folder level, then any remaining segments descend. |
+| Relative — downward | Does not start with `..` | `Revit Export` | Vault: `$/Designs/P-00020/CAD/Revit Export/` *(subfolder of source folder)* |
+
+### Path resolution rules
+
+1. **Empty or whitespace** → use the source file's Vault folder (current default).
+2. **Absolute** (starts with `$/`) → use the path as-is after normalising separators to `/`.
+3. **Relative** → resolve from the **source file's Vault folder** (`FindFoldersByIds` → `Folder.FullName`):
+   - If the path **starts with `..`**, apply standard `..` and `.` segment navigation from the source folder. Each `..` moves up one parent folder; any folder names after the `..` segments descend from the resulting location. Examples from `$/Designs/P-00020/CAD`: `..\Revit Export` → `$/Designs/P-00020/Revit Export`; `..\..\Common Exports` → `$/Designs/Common Exports`.
+   - If the path does **not** start with `..`, append it as a sub-path under the source folder. Example: `Revit Export` → `$/Designs/P-00020/CAD/Revit Export`. A leading `\` is stripped before appending.
+   - Normalise duplicate slashes; trim trailing `/`.
+4. **Folder creation** → walk the resolved Vault path segment by segment. Create any folder that does not exist using the Vault Document Service. Fail only if creation is denied by permissions.
+5. **Local mapping** → map the resolved Vault folder to a local directory via `WorkingFoldersManager` (same root used by `mDownloadFile`). Create the local directory if it does not exist.
+
+### Processing pipeline
+
+```mermaid
+flowchart TD
+    A[Settings.Load — ExportPath] --> B{ExportPath empty?}
+    B -->|Yes| C[Local dir = source file directory]
+    B -->|No| D[mResolveExportVaultFolder]
+    D --> E[Create missing Vault folders]
+    E --> F[mResolveExportLocalDirectory]
+    F --> G[Create local directory]
+    C --> H[Host app writes export files]
+    G --> H
+    H --> I[mUploadFiles]
+    I --> J[Derive Vault folder from local file path]
+    J --> K[Check-in + attach to source]
+```
+
+### Examples
+
+**Source file:** `$/Designs/P-00020/CAD/Assy.iam`
+
+| `ExportPath` | Resolved Vault folder | Export file |
+|---|---|---|
+| *(empty)* | `$/Designs/P-00020/CAD` | `Assy.iam.rvt` |
+| `$/Designs/Revit Exports` | `$/Designs/Revit Exports` | `Assy.iam.rvt` |
+| `..\Revit Export` | `$/Designs/P-00020/Revit Export` | `Assy.iam.rvt` |
+| `Revit Export` | `$/Designs/P-00020/CAD/Revit Export` | `Assy.iam.rvt` |
+| `..\..\Common Exports` | `$/Designs/Common Exports` | `Assy.iam.rvt` |
+
+**Source file:** `$/Designs/P-00020/CAD/Detail/Assy.iam`
+
+| `ExportPath` | Resolved Vault folder |
+|---|---|
+| `Revit Export` | `$/Designs/P-00020/CAD/Detail/Revit Export` *(subfolder of source folder)* |
+| `..\Revit Export` | `$/Designs/P-00020/CAD/Revit Export` *(one level up, then into `Revit Export`)* |
+| `..\..\Revit Export` | `$/Designs/P-00020/Revit Export` *(two levels up, then into `Revit Export`)* |
+
+### Per-job export file naming
+
+Export **filenames** are unchanged; only the **directory** changes. Each job builds the full export path as `Path.Combine(exportLocalDir, <existing filename logic>)`:
+
+| Job | Filename pattern (unchanged) |
+|---|---|
+| RVT | `<source>.iam.rvt` or `<source>.iam_<version>_<preset>.rvt` |
+| 2D DWG | `<source>.dwg` |
+| 3D | `<source>.dwg` / `.stp` / `.jt` |
+| Navisworks | `<source>.nwd` / `.dwf` / `.nwc` |
+| PDF | `<source>.pdf` / `.dxf` |
+| Image | `<source>.<ImgFileType>` |
+
+### Implementation scope
+
+| Component | Change |
+|---|---|
+| `adsk.ts.job.shared` — `JobCommon` | Add `mResolveExportVaultFolder`, `mResolveExportLocalDirectory`, `mEnsureVaultFolderExists`; update `mUploadFiles` to derive upload folder from local export path |
+| All 6 export jobs — `Settings.cs` | Add `[XmlElement("ExportPath")] public string ExportPath` |
+| All 6 export jobs — `*.settings.xml` | Add `<ExportPath></ExportPath>` with inline comments |
+| All 6 export jobs — `JobExtension.cs` | Resolve export directory after source download; write all export files there |
+| RVT — `JobExtension.cs` | Set `revitExportDef.Location` to resolved local directory |
+
+### XML configuration example
+
+```xml
+<!-- Export destination. Leave empty to export next to the source file. -->
+<!-- Absolute:        $/Designs/Revit Exports -->
+<!-- Relative up:     ..\Revit Export  or  ..\..\Common Exports  (.. = one level up per segment) -->
+<!-- Relative down:   Revit Export  (subfolder under the source file's folder) -->
+<ExportPath></ExportPath>
+```
 
 ---
 
@@ -358,4 +481,5 @@ The following settings appear in multiple jobs with identical meaning:
 | `AcceptLocalIpj` | Inventor-based jobs | When `True`, the job continues with a locally cached Inventor project file if the Vault download fails. |
 | `ExportFormats` | All export jobs | Selects the output format(s). Multiple values are comma-separated where supported. |
 | `CopySystemComment` | All export jobs | Controls whether the source file's comment is propagated to the export file. See the [CopySystemComment logic](#copysystemcomment-logic) section. |
-| `OutputPath` | All export jobs | When set, the job copies each exported file to this local path after uploading it to Vault. |
+| `ExportPath` | All export jobs | Optional Vault path (absolute or relative) for export file placement. Paths starting with `..` navigate upward from the source folder (multiple `..` segments supported); paths without a leading `..` resolve as subfolders of the source folder. Resolved to a local working-folder directory before export; uploaded to the matching Vault folder. Auto-creates missing Vault folders. See [Export Path Configuration](#export-path-configuration-exportpath). |
+| `OutputPath` | All export jobs | When set, the job copies each exported file to this local path after uploading it to Vault. Independent of `ExportPath`. |


### PR DESCRIPTION
Introduce ExportPath across all export jobs to resolve absolute or relative Vault folders into local working-folder paths, auto-create missing folders, and upload exports to the matching Vault location.